### PR TITLE
fix(smtp): enable TLS wrappermode for port 465 (SMTPS)

### DIFF
--- a/quant/entrypoints/00-smtp-relay.sh
+++ b/quant/entrypoints/00-smtp-relay.sh
@@ -41,6 +41,14 @@ if [ -n "$QUANT_SMTP_HOST" ] && [ "$QUANT_SMTP_RELAY_ENABLED" = "true" ]; then
     postconf -e "smtp_tls_security_level=secure"
     postconf -e "smtp_tls_note_starttls_offer=yes"
 
+    # Port 465 is SMTPS (implicit TLS) — wrap the connection from byte 0 instead
+    # of negotiating STARTTLS, which 465 endpoints do not speak.
+    if [ "$QUANT_SMTP_PORT" = "465" ]; then
+        postconf -e "smtp_tls_wrappermode=yes"
+    else
+        postconf -e "smtp_tls_wrappermode=no"
+    fi
+
     postconf -e "smtp_sasl_auth_enable=yes"
     postconf -e "smtp_sasl_security_options=noanonymous"
     postconf -e "smtp_sasl_password_maps=hash:/etc/postfix/sasl_passwd"

--- a/quant/entrypoints/00-ssmtp.sh
+++ b/quant/entrypoints/00-ssmtp.sh
@@ -40,6 +40,14 @@ if [ -n "$QUANT_SMTP_HOST" ] && [ "$QUANT_SMTP_RELAY_ENABLED" != "true" ]; then
     postconf -e "smtp_tls_note_starttls_offer=yes"
     postconf -e "smtp_tls_CAfile=/etc/ssl/certs/ca-certificates.crt"
 
+    # Port 465 is SMTPS (implicit TLS) — wrap the connection from byte 0 instead
+    # of negotiating STARTTLS, which 465 endpoints do not speak.
+    if [ "$QUANT_SMTP_PORT" = "465" ]; then
+        postconf -e "smtp_tls_wrappermode=yes"
+    else
+        postconf -e "smtp_tls_wrappermode=no"
+    fi
+
     # Configure SASL auth
     postconf -e "smtp_sasl_auth_enable=yes"
     postconf -e "smtp_sasl_security_options=noanonymous"


### PR DESCRIPTION
## Summary

- Port 465 is SMTPS / implicit TLS. Without \`smtp_tls_wrappermode=yes\`, postfix opens a plaintext socket on 465 and tries STARTTLS, which the endpoint does not speak — the handshake never completes and messages sit in the active queue forever.
- Both entrypoints (\`00-smtp-relay.sh\` and \`00-ssmtp.sh\`) now flip \`smtp_tls_wrappermode\` based on \`QUANT_SMTP_PORT\`.
- The \`else\` branch explicitly sets \`wrappermode=no\` so the entrypoint is idempotent across restarts if the port changes (e.g. 465 → 587) without an image rebuild.

## Context

Detected in production on a Drupal site relaying through AWS SES (\`email-smtp.ap-southeast-2.amazonaws.com:465\`). Symptoms: \`postdrop\` accepted mail and postfix queued it, but \`postqueue -p\` showed messages stuck in active and nothing was ever delivered. Confirmed via \`posttls-finger\` — without \`-w\` (wrappermode), the handshake to :465 stalls; with \`-w\` it succeeds.

After applying this fix and switching the test container to port 587 (to validate the existing STARTTLS path still works), the queued test message delivered cleanly and \`postqueue -p\` returned empty.

## Test plan

- [ ] Deploy a container with \`QUANT_SMTP_PORT=465\` against an SMTPS provider (SES, SendGrid, Mailgun, Postmark) and confirm \`postqueue -p\` clears after a send.
- [ ] Verify \`postconf smtp_tls_wrappermode\` returns \`yes\` when port is 465 and \`no\` for any other port.
- [ ] Verify a restart that changes the port from 465 to 587 ends up with \`wrappermode=no\` (idempotency).
- [ ] Verify existing 587 / STARTTLS deployments are unaffected.