### PR TITLE
Promote develop to main: SMTP wrappermode fix

### DIFF
--- a/quant/entrypoints/00-smtp-relay.sh
+++ b/quant/entrypoints/00-smtp-relay.sh
@@ -41,6 +41,14 @@ if [ -n "$QUANT_SMTP_HOST" ] && [ "$QUANT_SMTP_RELAY_ENABLED" = "true" ]; then
     postconf -e "smtp_tls_security_level=secure"
     postconf -e "smtp_tls_note_starttls_offer=yes"
 
+    # Port 465 is SMTPS (implicit TLS) — wrap the connection from byte 0 instead
+    # of negotiating STARTTLS, which 465 endpoints do not speak.
+    if [ "$QUANT_SMTP_PORT" = "465" ]; then
+        postconf -e "smtp_tls_wrappermode=yes"
+    else
+        postconf -e "smtp_tls_wrappermode=no"
+    fi
+
     postconf -e "smtp_sasl_auth_enable=yes"
     postconf -e "smtp_sasl_security_options=noanonymous"
     postconf -e "smtp_sasl_password_maps=hash:/etc/postfix/sasl_passwd"

--- a/quant/entrypoints/00-ssmtp.sh
+++ b/quant/entrypoints/00-ssmtp.sh
@@ -40,6 +40,14 @@ if [ -n "$QUANT_SMTP_HOST" ] && [ "$QUANT_SMTP_RELAY_ENABLED" != "true" ]; then
     postconf -e "smtp_tls_note_starttls_offer=yes"
     postconf -e "smtp_tls_CAfile=/etc/ssl/certs/ca-certificates.crt"
 
+    # Port 465 is SMTPS (implicit TLS) — wrap the connection from byte 0 instead
+    # of negotiating STARTTLS, which 465 endpoints do not speak.
+    if [ "$QUANT_SMTP_PORT" = "465" ]; then
+        postconf -e "smtp_tls_wrappermode=yes"
+    else
+        postconf -e "smtp_tls_wrappermode=no"
+    fi
+
     # Configure SASL auth
     postconf -e "smtp_sasl_auth_enable=yes"
     postconf -e "smtp_sasl_security_options=noanonymous"


### PR DESCRIPTION
## Summary

Promotes the SMTP wrappermode fix (#4) from \`develop\` to \`main\` so the new image gets built and published.

## Changes included

- 9ed51d0 — fix(smtp): enable TLS wrappermode for port 465 (SMTPS)

See #4 for full context, risk assessment, and the production repro on AWS SES.

## Test plan

- [ ] CI build on \`main\` completes after merge
- [ ] Downstream Drupal image (\`conga-quant-editorial-site\`) rebuilt against the new base
- [ ] Production mail on port 465 deployment delivers cleanly (queue clears, no \`postdrop\` errors)