### PR TITLE
build(deps): bump docker/setup-buildx-action from v4 to v5

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v5
 
       - name: Initialize Quant Cloud
         uses: quantcdn/quant-cloud-init-action@v1.1.5


### PR DESCRIPTION
Bumps `docker/setup-buildx-action` from v4 to v5 in the build/deploy workflow. (Tier-3 supply-chain PR-review e2e test.)